### PR TITLE
Fix: Add missing build tool

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod download
+    - GO111MODULE=on go get github.com/golang/mock/mockgen@v1.4.4
     - go generate ./...
 builds:
   - env:


### PR DESCRIPTION
Add command to install `github.com/golang/mock/mockgen@v1.4.4﻿`
to the goreleaser configuration file.
